### PR TITLE
Fix riscv_expand_block_move

### DIFF
--- a/gcc/config/riscv/riscv.c
+++ b/gcc/config/riscv/riscv.c
@@ -3234,7 +3234,7 @@ riscv_block_move_loop (rtx dest, rtx src, HOST_WIDE_INT length,
 bool
 riscv_expand_block_move (rtx dest, rtx src, rtx length)
 {
-  if (CONST_INT_P (length))
+  if (CONST_INT_P (length) && INTVAL (length) >= 0)
     {
       HOST_WIDE_INT factor, align;
 


### PR DESCRIPTION
The problem was sourced from the argument `length` in `riscv_expand_block_move` can be negative, which leads to a crash.
```c
bool
riscv_expand_block_move (rtx dest, rtx src, rtx length)
{
  if (CONST_INT_P (length))
    {
      HOST_WIDE_INT factor, align;

      align = MIN (MIN (MEM_ALIGN (src), MEM_ALIGN (dest)), BITS_PER_WORD);
      factor = BITS_PER_WORD / align;
      ... ...
```



Bug reproduce step for g++.dg/opt/memcpy1.C
```
gdb$ break riscv_expand_block_move
gdb$ print length->u.hwint[0] # INTVAL(length)
gdb$ $1 = -4
```



Also, it is valid to `memcpy` 0 byte in C standard (WG14/N1256  (7.21.1/2))
 ```
"""
Where an argument declared as size_t n specifies the length of the array for a
function, n can have the value zero on a call to that function. Unless explicitly stated
otherwise in the description of a particular function in this subclause, pointer arguments
on such a call shall still have valid values, as described in 7.1.4. On such a call, a
function that locates a character finds no occurrence, a function that compares two
character sequences returns zero, and a function that copies characters copies zero
characters.
"""
```