### PR TITLE
RISC-V: Disable fpr when using zfinx

### DIFF
--- a/gcc/config/riscv/riscv.c
+++ b/gcc/config/riscv/riscv.c
@@ -4806,12 +4806,10 @@ riscv_conditional_register_usage (void)
 	call_used_regs[r] = 1;
     }
 
-  if (!TARGET_HARD_FLOAT)
+  if (!TARGET_HARD_FLOAT || TARGET_ZFINX)
     {
-      if(!TARGET_ZFINX){
-         for (int regno = FP_REG_FIRST; regno <= FP_REG_LAST; regno++)
-	   fixed_regs[regno] = call_used_regs[regno] = 1;
-      }
+      for (int regno = FP_REG_FIRST; regno <= FP_REG_LAST; regno++)
+	fixed_regs[regno] = call_used_regs[regno] = 1;
     }
 
   /* In the soft-float ABI, there are no callee-saved FP registers.  */


### PR DESCRIPTION
We are actually not disabling fprs. I saw this in programs that used so many integer registers that gcc tried using floating point registers.