### PR TITLE
Remove unnecessary ZFINX check

### DIFF
--- a/gcc/config/riscv/riscv.c
+++ b/gcc/config/riscv/riscv.c
@@ -2478,7 +2478,7 @@ riscv_function_arg_boundary (machine_mode mode, const_tree type)
 static unsigned
 riscv_pass_mode_in_fpr_p (machine_mode mode)
 {
-  if (GET_MODE_UNIT_SIZE (mode) <= UNITS_PER_FP_ARG && !TARGET_ZFINX)
+  if (GET_MODE_UNIT_SIZE (mode) <= UNITS_PER_FP_ARG)
     {
       if (GET_MODE_CLASS (mode) == MODE_FLOAT)
 	return 1;


### PR DESCRIPTION
This function is not even checking whether we have `TARGET_HARD_FLOAT` so I don't see why we need a check against ZFINX. I don't have this in my fork and there are no problems.