### PR TITLE
fixup codegen for s|zext & slli.uw

### DIFF
--- a/gcc/config/riscv/bitmanip.md
+++ b/gcc/config/riscv/bitmanip.md
@@ -93,7 +93,7 @@
 (define_insn "*zero_extendsidi2_bitmanip"
   [(set (match_operand:DI 0 "register_operand" "=r,r")
 	(zero_extend:DI (match_operand:SI 1 "nonimmediate_operand" "r,m")))]
-  "TARGET_64BIT && (TARGET_ZBB || TARGET_ZBA)"
+  "TARGET_64BIT && TARGET_ZBA"
   "@
    zext.w\t%0,%1
    lwu\t%0,%1"

--- a/gcc/config/riscv/riscv.md
+++ b/gcc/config/riscv/riscv.md
@@ -1845,6 +1845,7 @@
 		(match_operand 3 "immediate_operand" "")))
    (clobber (match_scratch:DI 4 "=&r"))]
   "TARGET_64BIT
+   && !TARGET_ZBA
    && ((INTVAL (operands[3]) >> INTVAL (operands[2])) == 0xffffffff)"
   "#"
   "&& reload_completed"

--- a/gcc/config/riscv/riscv.md
+++ b/gcc/config/riscv/riscv.md
@@ -1061,15 +1061,16 @@
 	(zero_extend:DI (match_operand:SI 1 "nonimmediate_operand")))]
   "TARGET_64BIT")
 
-(define_insn_and_split "zero_extendsidi2_internal"
+(define_insn_and_split "*zero_extendsidi2_internal"
   [(set (match_operand:DI     0 "register_operand"     "=r,r")
 	(zero_extend:DI
 	    (match_operand:SI 1 "nonimmediate_operand" " r,m")))]
-  "TARGET_64BIT && !(TARGET_ZBA || TARGET_ZBB)"
+  "TARGET_64BIT && !TARGET_ZBA"
   "@
    #
    lwu\t%0,%1"
-  "&& reload_completed
+  "&& !TARGET_ZBA
+   && reload_completed
    && REG_P (operands[1])
    && !paradoxical_subreg_p (operands[0])"
   [(set (match_dup 0)
@@ -1088,11 +1089,12 @@
   [(set (match_operand:GPR    0 "register_operand"     "=r,r")
 	(zero_extend:GPR
 	    (match_operand:HI 1 "nonimmediate_operand" " r,m")))]
-  "!(TARGET_ZBA || TARGET_ZBB)"
+  "!TARGET_ZBB"
   "@
    #
    lhu\t%0,%1"
   "&& reload_completed
+   && !TARGET_ZBB
    && REG_P (operands[1])
    && !paradoxical_subreg_p (operands[0])"
   [(set (match_dup 0)
@@ -1139,11 +1141,12 @@
   [(set (match_operand:SUPERQI   0 "register_operand"     "=r,r")
 	(sign_extend:SUPERQI
 	    (match_operand:SHORT 1 "nonimmediate_operand" " r,m")))]
-  ""
+  "!TARGET_ZBB"
   "@
    #
    l<SHORT:size>\t%0,%1"
   "&& reload_completed
+   && !TARGET_ZBB
    && REG_P (operands[1])
    && !paradoxical_subreg_p (operands[0])"
   [(set (match_dup 0) (ashift:SI (match_dup 1) (match_dup 2)))

--- a/gcc/testsuite/gcc.target/riscv/rvb-adduw.c
+++ b/gcc/testsuite/gcc.target/riscv/rvb-adduw.c
@@ -1,0 +1,10 @@
+/* { dg-do compile } */
+/* { dg-options "-march=rv64gc_zba -mabi=lp64 -O2" } */
+
+long
+foo (int i, unsigned int j)
+{
+  return i + (long)j;
+}
+
+/* { dg-final { scan-assembler "add.uw" } } */


### PR DESCRIPTION
also one proposal: 
output template in (define_insn "*zero_extendsidi2_bitmanip") can be changed to `add.uw\t%0,%1,zero`


test result:
```
/home/sinan/plct/riscv-gnu-toolchain/scripts/testsuite-filter gcc newlib /home/sinan/plct/riscv-gnu-toolchain/test/allowlist `find build-gcc-newlib-stage2/gcc/testsuite/ -name *.sum |paste -sd "," -`

               ========= Summary of gcc testsuite =========
                            | # of unexpected case / # of unique unexpected case
                            |          gcc |          g++ |     gfortran |
     rv64gc/  lp64d/ medlow |    0 /     0 |    0 /     0 |      - |
```