### PR TITLE
skip testcase gen-vect-11c

### DIFF
--- a/gcc/testsuite/gcc.dg/tree-ssa/gen-vect-11c.c
+++ b/gcc/testsuite/gcc.dg/tree-ssa/gen-vect-11c.c
@@ -2,6 +2,7 @@
 /* { dg-options "-O2 -ftree-vectorize -fdump-tree-vect-details" } */
 /* { dg-options "-O2 -ftree-vectorize -fdump-tree-vect-details -mno-vx" { target { s390*-*-* } } } */
 /* { dg-options "-O2 -ftree-vectorize -fdump-tree-vect-details -mno-sse" { target { i?86-*-* x86_64-*-* } } } */
+/* { dg-options "-O2 -ftree-vectorize -fdump-tree-vect-details -march=rv64gc" { target { riscv*-*-* } } } */
 
 #include <stdlib.h>
 


### PR DESCRIPTION
skip testcase gen-vect-11c, since we dont have option to disable autovectorization on P