### PR TITLE
fix wrong vector type in rvv and add checker field for rvp builtin macro

### DIFF
--- a/gcc/config/riscv/riscv-builtins.c
+++ b/gcc/config/riscv/riscv-builtins.c
@@ -241,14 +241,14 @@ DECL_CHECKER(vector_tuple_extract)
    are as for RISCV_BUILTIN.  */
 #define DIRECT_BUILTIN_NO_PREFIX(INSN, NAME, FUNCTION_TYPE, AVAIL)			\
   { CODE_FOR_ ## INSN, "__builtin_riscv_" # NAME,			\
-    RISCV_BUILTIN_DIRECT, FUNCTION_TYPE, riscv_builtin_avail_ ## AVAIL }
+    RISCV_BUILTIN_DIRECT, FUNCTION_TYPE, riscv_builtin_avail_ ## AVAIL, NULL}
 
 /* Define __builtin_riscv_<NAME>, which is a RISCV_BUILTIN_DIRECT_NO_TARGET function
    mapped to instruction CODE_FOR_<INSN>,  FUNCTION_TYPE and AVAIL
    are as for RISCV_BUILTIN.  */
 #define DIRECT_NO_TARGET_BUILTIN_NO_PREFIX(INSN, NAME, FUNCTION_TYPE, AVAIL)			\
   { CODE_FOR_ ## INSN, "__builtin_riscv_" # NAME,			\
-    RISCV_BUILTIN_DIRECT_NO_TARGET, FUNCTION_TYPE, riscv_builtin_avail_ ## AVAIL }
+    RISCV_BUILTIN_DIRECT_NO_TARGET, FUNCTION_TYPE, riscv_builtin_avail_ ## AVAIL, NULL }
 
 #define DIRECT_NO_TARGET_BUILTIN_WITH_CHECKER(INSN, FUNCTION_TYPE, AVAIL, CHECKER) \
   RISCV_BUILTIN_WITH_CHECKER (INSN, #INSN, RISCV_BUILTIN_DIRECT_NO_TARGET,		\

--- a/gcc/config/riscv/riscv-builtins.c
+++ b/gcc/config/riscv/riscv-builtins.c
@@ -3248,8 +3248,11 @@ riscv_prepare_builtin_arg (struct expand_operand *op, tree exp, unsigned argno,
 {
   rtx arg_rtx = expand_normal (CALL_EXPR_ARG (exp, argno));
   enum machine_mode mode = insn_data[icode].operand[argno + has_target_p].mode;
+  bool flag = (riscv_rvp_support_vector_mode_p (mode)
+	| riscv_rvp_support_vector_mode_p (GET_MODE (arg_rtx)))
+	& TARGET_ZPN;
 
-  if (TARGET_ZPN &&
+  if (flag &&
       !(*insn_data[icode].operand[argno + has_target_p].predicate) (arg_rtx, mode))
     {
       rtx tmp_rtx = gen_reg_rtx (mode);

--- a/gcc/config/riscv/riscv-protos.h
+++ b/gcc/config/riscv/riscv-protos.h
@@ -74,6 +74,7 @@ extern bool riscv_expand_block_move (rtx, rtx, rtx);
 extern bool riscv_store_data_bypass_p (rtx_insn *, rtx_insn *);
 extern rtx riscv_gen_gpr_save_insn (struct riscv_frame_info *);
 extern bool riscv_gpr_save_operation_p (rtx);
+extern bool riscv_rvp_support_vector_mode_p (machine_mode mode);
 
 /* Routines for vector support.  */
 bool riscv_const_vec_all_same_in_range_p (rtx, HOST_WIDE_INT, HOST_WIDE_INT);

--- a/gcc/config/riscv/rvp.md
+++ b/gcc/config/riscv/rvp.md
@@ -7012,7 +7012,7 @@
 (define_expand "movv2si"
   [(set (match_operand:V2SI 0 "")
 	(match_operand:V2SI 1 ""))]
-  "TARGET_64BIT && TARGET_ZPN "
+  "TARGET_ZPN "
 {
   if (riscv_legitimize_move (V2SImode, operands[0], operands[1]))
     DONE;
@@ -7021,7 +7021,7 @@
 (define_insn "*movv2si_64bit"
   [(set (match_operand:V2SI 0 "nonimmediate_operand" "=r,r,r, m,  *f,*f,*r,*f,*m")
 	(match_operand:V2SI 1 "move_operand"         " r,T,m,rJ,*r*J,*m,*f,*f,*f"))]
-  "TARGET_64BIT && TARGET_ZPN
+  "TARGET_ZPN
    && (register_operand (operands[0], V2SImode)
        || reg_or_0_operand (operands[1], V2SImode))"
   { return riscv_output_move (operands[0], operands[1]); }


### PR DESCRIPTION
This patch will help you avoid millions of annoying warnnings.